### PR TITLE
Rollup of multiple commits

### DIFF
--- a/ndi-examples/src/data_lifetime.rs
+++ b/ndi-examples/src/data_lifetime.rs
@@ -25,5 +25,5 @@ fn main() {
 
     thread::sleep(std::time::Duration::from_millis(1000));
 
-    println!("Frame received: {}x{}", frame.xres(), frame.yres());
+    println!("Frame received: {}x{}", frame.width(), frame.height());
 }

--- a/ndi-examples/src/multithread.rs
+++ b/ndi-examples/src/multithread.rs
@@ -11,10 +11,7 @@ fn main() {
     let sources = find.current_sources(1000).unwrap();
 
     let mut recv = ndi::RecvBuilder::new().build().unwrap();
-    println!(
-        "Connecting to the first source: {}",
-        sources[0].get_name()
-    );
+    println!("Connecting to the first source: {}", sources[0].get_name());
     recv.connect(&sources[0]);
 
     let recv_arc = Arc::new(recv);

--- a/ndi-examples/src/multithread.rs
+++ b/ndi-examples/src/multithread.rs
@@ -13,7 +13,7 @@ fn main() {
     let mut recv = ndi::RecvBuilder::new().build().unwrap();
     println!(
         "Connecting to the first source: {}",
-        sources[0].get_name().unwrap_or("[invalid-name]".into())
+        sources[0].get_name()
     );
     recv.connect(&sources[0]);
 
@@ -57,8 +57,8 @@ fn main() {
         if let Ok(video_data) = video_rx.recv().map_err(|e| e.to_string()) {
             println!(
                 "Received video on main thread: {}x{}",
-                video_data.xres(),
-                video_data.yres()
+                video_data.width(),
+                video_data.height()
             );
         }
 

--- a/ndi-examples/src/recv.rs
+++ b/ndi-examples/src/recv.rs
@@ -17,7 +17,7 @@ fn main() {
         println!(
             "  {}: {}",
             i,
-            source.get_name().unwrap_or("[invalid-name]".into())
+            source.get_name()
         );
     }
 
@@ -32,7 +32,7 @@ fn main() {
     let mut recv = recv_builder.build().unwrap();
     recv.connect(&sources[i]);
 
-    let name = sources[i].get_name().unwrap();
+    let name = sources[i].get_name();
     println!("Connected to NDI device {}", name);
 
     let start = Instant::now();
@@ -51,8 +51,8 @@ fn main() {
                 let video_data = video_data.expect("Failed to get video data from capture");
                 println!(
                     "Got video data: {}x{} {:?}",
-                    video_data.xres(),
-                    video_data.yres(),
+                    video_data.width(),
+                    video_data.height(),
                     video_data.four_cc()
                 );
             }

--- a/ndi-examples/src/recv.rs
+++ b/ndi-examples/src/recv.rs
@@ -14,11 +14,7 @@ fn main() {
 
     println!("Select device:");
     for (i, source) in sources.iter().enumerate() {
-        println!(
-            "  {}: {}",
-            i,
-            source.get_name()
-        );
+        println!("  {}: {}", i, source.get_name());
     }
 
     let stdin = io::stdin();

--- a/ndi-examples/src/save_recv.rs
+++ b/ndi-examples/src/save_recv.rs
@@ -25,13 +25,13 @@ fn main() {
 
     let frame_vec = unsafe {
         assert!(!frame.p_data().is_null());
-        let size = frame.yres() * frame.line_stride_in_bytes().unwrap();
+        let size = frame.width() * frame.line_stride_in_bytes().unwrap();
         std::slice::from_raw_parts(frame.p_data(), size as _)
     };
     let frame_vec = Vec::from_iter(frame_vec.to_owned());
     let buf = image::ImageBuffer::<image::Rgba<u8>, Vec<_>>::from_vec(
-        frame.xres(),
-        frame.yres(),
+        frame.width(),
+        frame.height(),
         frame_vec,
     )
     .ok_or("Failed to create image")

--- a/ndi/src/internal/mod.rs
+++ b/ndi/src/internal/mod.rs
@@ -4,6 +4,8 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
+use std::ops::{Deref, DerefMut};
+
 #[cfg(target_os = "windows")]
 mod bindings_windows;
 
@@ -16,4 +18,51 @@ pub mod bindings {
 
     #[cfg(target_os = "linux")]
     pub use super::bindings_linux::*;
+}
+
+/// Utility for adding a destructor function to a pointer which is called once the struct is dropped.
+pub(crate) struct OnDrop<P: Copy> {
+    inner: P,
+    destroy: fn(P),
+}
+
+impl<T> OnDrop<*mut T> {
+    pub(crate) fn new(inner: *mut T, destroy: fn(*mut T)) -> Self {
+        OnDrop { inner, destroy }
+    }
+}
+
+impl<P: Copy> Deref for OnDrop<P> {
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<P: Copy> DerefMut for OnDrop<P> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<P: Copy> Drop for OnDrop<P> {
+    fn drop(&mut self) {
+        (self.destroy)(self.inner);
+    }
+}
+
+#[test]
+fn on_drop_simple() {
+    fn drop_boxed_i32(b: *mut i32) {
+        let b = unsafe { Box::from_raw(b) };
+        assert_eq!(*b, 5);
+        drop(b);
+    }
+
+    let num = Box::into_raw(Box::new(2));
+    unsafe { *num += 3 };
+
+    let on_drop = OnDrop::new(num, drop_boxed_i32);
+    drop(on_drop);
 }

--- a/ndi/src/internal/mod.rs
+++ b/ndi/src/internal/mod.rs
@@ -1,7 +1,8 @@
-#![allow(non_upper_case_globals)]
+#![allow(dead_code)]
+#![allow(deref_nullptr)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![allow(dead_code)]
+#![allow(non_upper_case_globals)]
 
 #[cfg(target_os = "windows")]
 mod bindings_windows;

--- a/ndi/src/lib.rs
+++ b/ndi/src/lib.rs
@@ -401,8 +401,8 @@ unsafe impl core::marker::Sync for VideoData {}
 impl Debug for VideoData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VideoData")
-            .field("xres", &self.xres())
-            .field("yres", &self.yres())
+            .field("width", &self.width())
+            .field("height", &self.height())
             .field("line_stride_in_bytes", &self.line_stride_in_bytes())
             .field("data_size", &self.data_size_in_bytes())
             .field("fourcc", &self.four_cc())
@@ -462,12 +462,12 @@ impl VideoData {
     /// Note that, because data is internally all considered
     /// in 4:2:2 formats, image width values
     /// should be divisible by two.
-    pub fn xres(&self) -> u32 {
+    pub fn width(&self) -> u32 {
         self.p_instance.xres as _
     }
 
     /// The height of the frame expressed in pixels.
-    pub fn yres(&self) -> u32 {
+    pub fn height(&self) -> u32 {
         self.p_instance.yres as _
     }
 
@@ -503,6 +503,11 @@ impl VideoData {
     /// ```
     pub fn frame_rate_d(&self) -> u32 {
         self.p_instance.frame_rate_D as _
+    }
+
+    /// The framerate of the current frame.
+    pub fn frame_rate(&self) -> f32 {
+        self.p_instance.frame_rate_N as f32 / self.p_instance.frame_rate_D as f32
     }
 
     /// The SDK defines picture aspect ratio (as opposed to pixel aspect ratios).

--- a/ndi/src/lib.rs
+++ b/ndi/src/lib.rs
@@ -322,18 +322,18 @@ impl Source {
     ///     MACHINE_NAME (NDI_SOURCE_NAME)
     /// If the parameter was passed either as NULL, or an EMPTY string then
     /// the specific IP address and port number from below is used.
-    pub fn get_name(&self) -> Result<String, std::str::Utf8Error> {
+    pub fn get_name(&self) -> String {
         let name_char_ptr: *mut std::os::raw::c_char = self.p_instance.p_ndi_name as _;
         if name_char_ptr.is_null() {
-            return Ok(String::new());
+            return String::new();
         }
         let name = unsafe {
             CStr::from_ptr(name_char_ptr)
                 .to_owned()
-                .to_str()?
+                .to_string_lossy()
                 .to_string()
         };
-        Ok(name)
+        name
     }
 }
 

--- a/ndi/src/send.rs
+++ b/ndi/src/send.rs
@@ -102,7 +102,7 @@ impl SendBuilder {
 
 /// A sender struct for sending NDI
 pub struct Send {
-    p_instance: Arc<NDIlib_send_instance_t>,
+    p_instance: Arc<OnDrop<NDIlib_send_instance_t>>,
 }
 
 impl Send {
@@ -117,7 +117,9 @@ impl Send {
         }
 
         Ok(Self {
-            p_instance: Arc::new(p_instance),
+            p_instance: Arc::new(OnDrop::new(p_instance, |s| unsafe {
+                NDIlib_send_destroy(s)
+            })),
         })
     }
 
@@ -129,7 +131,9 @@ impl Send {
         }
 
         Ok(Self {
-            p_instance: Arc::new(p_instance),
+            p_instance: Arc::new(OnDrop::new(p_instance, |s| unsafe {
+                NDIlib_send_destroy(s)
+            })),
         })
     }
 
@@ -140,7 +144,7 @@ impl Send {
         unsafe {
             let p_tally = *tally;
             let is_updated =
-                NDIlib_send_get_tally(*self.p_instance, &mut p_tally.into(), timeout_ms);
+                NDIlib_send_get_tally(**self.p_instance, &mut p_tally.into(), timeout_ms);
             is_updated
         }
     }
@@ -153,10 +157,10 @@ impl Send {
             } else {
                 MaybeUninit::uninit()
             };
-            let frametype = NDIlib_send_capture(*self.p_instance, p_meta.as_mut_ptr(), timeout_ms);
+            let frametype = NDIlib_send_capture(**self.p_instance, p_meta.as_mut_ptr(), timeout_ms);
 
             *meta_data = Some(MetaData::from_binding_send(
-                self.p_instance.clone(),
+                Arc::clone(&self.p_instance),
                 p_meta.assume_init(),
             ));
 
@@ -168,28 +172,29 @@ impl Send {
 
     /// Retrieve the source information for the given sender instance.
     pub fn get_source(&self) -> Source {
-        let instance = unsafe { *NDIlib_send_get_source_name(*self.p_instance) };
-        Source::from_binding(instance)
+        let instance = unsafe { *NDIlib_send_get_source_name(**self.p_instance) };
+        let parent = SourceParent::Send(Arc::clone(&self.p_instance));
+        Source::from_binding(parent, instance)
     }
 
     /// This will add a metadata frame
     pub fn send_metadata(&self, metadata: &MetaData) {
         unsafe {
-            NDIlib_send_send_metadata(*self.p_instance, &metadata.p_instance);
+            NDIlib_send_send_metadata(**self.p_instance, &metadata.p_instance);
         }
     }
 
     /// This will add an audio frame
     pub fn send_audio(&self, audio_data: &AudioData) {
         unsafe {
-            NDIlib_send_send_audio_v3(*self.p_instance, &audio_data.p_instance);
+            NDIlib_send_send_audio_v3(**self.p_instance, &audio_data.p_instance);
         }
     }
 
     /// This will add a video frame
     pub fn send_video(&self, video_data: &VideoData) {
         unsafe {
-            NDIlib_send_send_video_v2(*self.p_instance, &video_data.p_instance);
+            NDIlib_send_send_video_v2(**self.p_instance, &video_data.p_instance);
         }
     }
 
@@ -210,7 +215,7 @@ impl Send {
     /// - Dropping a [`Send`] instance
     pub fn send_video_async(&self, video_data: &VideoData) {
         unsafe {
-            NDIlib_send_send_video_async_v2(*self.p_instance, &video_data.p_instance);
+            NDIlib_send_send_video_async_v2(**self.p_instance, &video_data.p_instance);
         }
     }
 
@@ -220,7 +225,7 @@ impl Send {
     /// which can significantly improve the efficiency if you want to make a lot of sources available on the network.
     /// If you specify a timeout that is not 0 then it will wait until there are connections for this amount of time.
     pub fn get_no_connections(&self, timeout_ms: u32) -> u32 {
-        unsafe { NDIlib_send_get_no_connections(*self.p_instance, timeout_ms) as _ }
+        unsafe { NDIlib_send_get_no_connections(**self.p_instance, timeout_ms) as _ }
     }
 
     // Free the buffers returned by capture for metadata
@@ -229,12 +234,4 @@ impl Send {
     //         NDIlib_send_free_metadata(*self.p_instance, &metadata.p_instance);
     //     }
     // }
-}
-
-impl Drop for Send {
-    fn drop(&mut self) {
-        unsafe {
-            NDIlib_send_destroy(*self.p_instance);
-        }
-    }
 }


### PR DESCRIPTION
- Make `Source::get_name` lossy and infallible
- Add `frame_rate` and rename `xres`/`yres` to `width` and `height`
- Refactor memory management using `OnDrop<T>`